### PR TITLE
Repository link for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,9 @@
   "dependencies": {
     "mime": "^2.4.2"
   },
-  "author": "Barry Yan <barry.yansh@gmail.com>"
+  "author": "Barry Yan <barry.yansh@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BarryYan/parcel-plugin-css-url-loader.git"
+  }
 }


### PR DESCRIPTION
Your `package.json` file does not have repository link therefore on `npm` registry not direct link on `git` repository.
It link will be useful if someone wants to see code source.

Thanks.