### PR TITLE
Add .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+node_modules/
+example/
+dist/
+.cache/
+
+.DS_Store
+*.tgz
+*.log*


### PR DESCRIPTION
Added `.npmignore` file.

This file excludes directories `node_module/` and `example/` from `npm` package. As a result of `npm` package gets smaller.

1.3kb from 6.6kb.

Thanks!